### PR TITLE
Fix config param when getting output directory

### DIFF
--- a/src/commands/merge.js
+++ b/src/commands/merge.js
@@ -22,7 +22,7 @@ export function merge(config = { config: { specs: [] } }) {
       promises.push(
         new Promise(async (resolve, reject) => {
           try {
-            const outputDir = getOutputDirFromConfig(config);
+            const outputDir = getOutputDirFromConfig(config.config);
             const filename = path.basename(spec.file);
             const api = await bundleSpec(config, spec);
 


### PR DESCRIPTION
Fixes an error, where setting the output directory in the `config.json` doesn't work.

config.json
```json
{
  "folder": "./specs",
  "output": "destination",
  "specs": [
    {
      "file": "abc.yml"
    }
  ]
}
```

CLI
```bash
$ npx openapi-dev-tool merge -v

No output provided, default one is in the current directory
```
