### PR TITLE
Fix viewsFolder check in config-validation.js

### DIFF
--- a/src/lib/config-validation.js
+++ b/src/lib/config-validation.js
@@ -306,7 +306,7 @@ export function serveValidation(options) {
   if (options.viewsFolder) {
     if (
       !fs.existsSync(options.viewsFolder) ||
-      fs.lstatSync(options.viewsFolder).isDirectory()
+      !fs.lstatSync(options.viewsFolder).isDirectory()
     ) {
       errors.push(`viewsFolder '${options.viewsFolder}' does not exist`);
     }


### PR DESCRIPTION
When serving a spec with a viewsFolder config, I get an error, although the directory exists.

This should fix this.

Cheers,
Sascha