### PR TITLE
Use maven to publish to local repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 .openapi-dev-toolrc
 doc-assets/*.stg
 .specs
+.idea

--- a/README.md
+++ b/README.md
@@ -194,15 +194,13 @@ Usage can be displayed by typing the command
 ```
 openapi-dev-tool publish-local
 
-  Publish into a local Maven repository
+  Publish into the local Maven repository
 
 Command Options
 
   -b, --skipBundle               Skips bundle openapi files into one before serving or publishing, default is
                                  false
   -g, --groupId string           GroupId used in repo server, default is com.openapi
-  -d, --repoPath string          Path of Maven local repository, default is 'auto': determinated automatically
-                                 by using 'mvn' command (if available)
   -x, --skipValidation           Skips OpenAPI validation process, default is false
 
 Global Options
@@ -218,7 +216,7 @@ Global Options
 
 > **Warning**
 >
-> By using `repoPath` with `auto`, `openapi-dev-tool` is going to determinate local repository path automatically from `mvn` command. So, in this mode, `mvn` command has to be available in PATH.
+> `openapi-dev-tool` is going to determinate local repository path automatically from `mvn` command. So, for this to work, `mvn` command has to be available in PATH.
 
 ### Merging
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lyra-network/openapi-dev-tool",
-  "version": "9.7.0",
+  "version": "9.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lyra-network/openapi-dev-tool",
-      "version": "9.7.0",
+      "version": "9.8.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@apidevtools/swagger-parser": "10.1.0",
@@ -36,6 +36,7 @@
         "lodash.flatmap": "^4.5.0",
         "lodash.flatten": "^4.4.0",
         "lodash.merge": "^4.6.2",
+        "maven": "^5.0.0",
         "mkdirp": "1.0.4",
         "promise-settle": "0.3.0",
         "rc": "1.2.8",
@@ -7871,6 +7872,15 @@
       },
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/maven": {
+      "version": "5.0.0",
+      "resolved": "https://nexus.lbg.office.fr.lyra/repository/npm-all/maven/-/maven-5.0.0.tgz",
+      "integrity": "sha512-GFor/ZwWLCYXTY5GnuH2l78O21FBLzTHA37kZNHH8MuahcLTQGHXTgC2x7dp+IQyEHGt4RrI/vCcy6lL8PqNoA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/mdast-util-find-and-replace": {
@@ -19211,6 +19221,11 @@
       "version": "4.1.0",
       "resolved": "https://nexus.lbg.office.fr.lyra/repository/npm-all/marked/-/marked-4.1.0.tgz",
       "integrity": "sha512-+Z6KDjSPa6/723PQYyc1axYZpYYpDnECDaU6hkaf5gqBieBkMKYReL5hteF2QizhlMbgbo8umXl/clZ67+GlsA=="
+    },
+    "maven": {
+      "version": "5.0.0",
+      "resolved": "https://nexus.lbg.office.fr.lyra/repository/npm-all/maven/-/maven-5.0.0.tgz",
+      "integrity": "sha512-GFor/ZwWLCYXTY5GnuH2l78O21FBLzTHA37kZNHH8MuahcLTQGHXTgC2x7dp+IQyEHGt4RrI/vCcy6lL8PqNoA=="
     },
     "mdast-util-find-and-replace": {
       "version": "1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lyra-network/openapi-dev-tool",
-  "version": "9.8.0",
+  "version": "9.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lyra-network/openapi-dev-tool",
-      "version": "9.8.0",
+      "version": "9.7.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@apidevtools/swagger-parser": "10.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lyra-network/openapi-dev-tool",
-  "version": "9.7.0",
+  "version": "9.8.0",
   "description": "OpenAPI Development tool",
   "main": "dist/src/lib.js",
   "scripts": {
@@ -52,6 +52,7 @@
     "lodash.flatmap": "^4.5.0",
     "lodash.flatten": "^4.4.0",
     "lodash.merge": "^4.6.2",
+    "maven": "^5.0.0",
     "mkdirp": "1.0.4",
     "promise-settle": "0.3.0",
     "rc": "1.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lyra-network/openapi-dev-tool",
-  "version": "9.8.0",
+  "version": "9.7.1",
   "description": "OpenAPI Development tool",
   "main": "dist/src/lib.js",
   "scripts": {

--- a/src/commands/publish-local.js
+++ b/src/commands/publish-local.js
@@ -5,8 +5,9 @@ import settle from 'promise-settle';
 import fs from 'fs';
 
 import { generateSpecsArchive } from '../lib/archiver';
-import { getPOMContent, getTempDir } from '../lib/utils';
+import { getTempDir, getPOMContent } from '../lib/utils';
 import { bundleSpec, writeOpenApiDocumentToFile } from '../lib/bundler';
+import { getRepoPath, installToLocalRepository } from '../lib/maven';
 
 // ##################################################################
 // The aim of this file is manage the publish command
@@ -17,7 +18,7 @@ export function publishLocal(config = { config: { specs: [] } }) {
 
   const artifactIds = [];
 
-  console.log('\tPublishing into: %s\n', config.repoPath);
+  console.log('\tPublishing into: %s\n', getRepoPath());
 
   // Publish for each spec
   // We filter to work only on enabled specs
@@ -91,11 +92,7 @@ export function publishLocal(config = { config: { specs: [] } }) {
             fs.writeFileSync(pomFile, pomContent);
 
             // Install with maven plugin
-            const mvn = require('maven').create({ quiet: true });
-            await mvn.execute(['install:install-file'], {
-              file: archive,
-              pomFile: pomFile,
-            });
+            await installToLocalRepository(archive, pomFile);
           } catch (err) {
             console.error(
               colors.red(

--- a/src/lib/config-definitions.js
+++ b/src/lib/config-definitions.js
@@ -172,14 +172,6 @@ const publishLocalOptionsDefinitions = [
     description: 'GroupId used in repo server, default is com.openapi',
   },
   {
-    name: 'repoPath',
-    alias: 'd',
-    type: String,
-    defaultValue: 'auto',
-    description:
-      "Path of Maven local repository, default is 'auto': determinated automatically by using 'mvn' command (if available)",
-  },
-  {
     name: 'skipValidation',
     alias: 'x',
     type: Boolean,

--- a/src/lib/config-validation.js
+++ b/src/lib/config-validation.js
@@ -323,55 +323,31 @@ export async function publishLocalValidation(options) {
   const optionsBack = options;
   options = { ...options, ...rc('openapi-dev-tool'), config: options.config };
 
-  // User and password can be overriden from command line
-  if (optionsBack.repoPath && optionsBack.repoPath !== 'auto')
-    options.repoPath = optionsBack.repoPath;
-
   let errors = [];
 
   if (!options.config || typeof options.config !== 'string') {
     errors.push(`config is mandatory`);
   }
 
-  if (!options.repoPath || typeof options.repoPath !== 'string') {
-    errors.push(`repoPath is mandatory`);
-  }
-
   if (!options.groupId || typeof options.groupId !== 'string') {
     errors.push(`groupId is mandatory`);
   }
 
-  // If repoPath is not auto then directory has to exist
-  if (
-    options.repoPath &&
-    typeof options.repoPath === 'string' &&
-    options.repoPath !== 'auto' &&
-    !fs.existsSync(options.repoPath)
-  ) {
-    errors.push(`repoPath '${options.repoPath}' folder does not exist`);
-  }
-
-  // If repoPath is auto then trying to determinate by using mvn command
-  if (
-    options.repoPath &&
-    typeof options.repoPath === 'string' &&
-    options.repoPath === 'auto'
-  ) {
-    if (!mvnExists()) {
-      errors.push(
-        `'${mavenCommand}' command does not exist. Impossible to determinate local repo path.`
-      );
-    } else {
-      options.repoPath = getRepoPath();
-      if (!fs.existsSync(options.repoPath)) {
-        errors.push(`repoPath '${options.repoPath}' does not exist`);
-      }
+  // Check local repository path by using mvn command
+  if (!mvnExists()) {
+    errors.push(
+      `'${mavenCommand}' command does not exist. Impossible to determinate local repository path.`
+    );
+  } else {
+    const repoPath = getRepoPath();
+    if (!fs.existsSync(repoPath)) {
+      errors.push(`Local repository '${repoPath}' does not exist`);
     }
   }
 
   await globalValidation(options, errors);
 
-  if (errors.length != 0) {
+  if (errors.length !== 0) {
     console.log(colors.red('Syntax error!'));
     errors.forEach((error) => {
       console.log(`\t- ${error}`);

--- a/src/lib/maven.js
+++ b/src/lib/maven.js
@@ -6,6 +6,8 @@ import commandExists from 'command-exists';
 import AdmZip from 'adm-zip';
 import { downloadFile } from './utils';
 
+import maven from 'maven';
+
 export const mavenCommand = 'mvn';
 
 const mavenLocalPathCmd = `${mavenCommand} help:evaluate -Dexpression=settings.localRepository -q -DforceStdout`;
@@ -77,5 +79,13 @@ export function downloadArtifact(artifact, urlDownloadTemplate, verbose) {
         if (fs.existsSync(`${folder}`)) rimraf.sync(`${folder}`);
         reject(err);
       });
+  });
+}
+
+export async function installToLocalRepository(archive, pomFile) {
+  const mvnInstance = maven.create({ quiet: true });
+  await mvnInstance.execute(['install:install-file'], {
+    file: archive,
+    pomFile: pomFile,
   });
 }

--- a/src/lib/maven.js
+++ b/src/lib/maven.js
@@ -2,11 +2,10 @@ import { execSync } from 'child_process';
 import rimraf from 'rimraf';
 import fs from 'fs';
 import commandExists from 'command-exists';
-
 import AdmZip from 'adm-zip';
-import { downloadFile } from './utils';
-
 import maven from 'maven';
+
+import { downloadFile } from './utils';
 
 export const mavenCommand = 'mvn';
 

--- a/tests/lib/config.spec.js
+++ b/tests/lib/config.spec.js
@@ -259,31 +259,6 @@ describe('config.js file', function () {
       assert.equal(exitCode, 1);
     });
 
-    it('should return error when repoPath is not sent in publish-local command', async function () {
-      process.argv[2] = 'publish-local';
-      process.argv[3] = '--config';
-      process.argv[4] = `${__dirname}/../assets/config_ok.json`;
-      process.argv[5] = '--repoPath';
-      await require('../../src/lib/config');
-      assert.equal(messages.length, 3);
-      assert.include(messages[0], 'Syntax error!');
-      assert.include(messages[1], 'repoPath is mandatory');
-      assert.equal(exitCode, 1);
-    });
-
-    it('should return error when repoPath is invalid in publish-local command', async function () {
-      process.argv[2] = 'publish-local';
-      process.argv[3] = '--config';
-      process.argv[4] = `${__dirname}/../assets/config_ok.json`;
-      process.argv[5] = '--repoPath';
-      process.argv[6] = 'fake';
-      await require('../../src/lib/config');
-      assert.equal(messages.length, 3);
-      assert.include(messages[0], 'Syntax error!');
-      assert.include(messages[1], "repoPath 'fake' folder does not exist");
-      assert.equal(exitCode, 1);
-    });
-
     it('should return error when repoServer is incorrect in publish command', async function () {
       process.argv[2] = 'publish';
       process.argv[3] = '--config';


### PR DESCRIPTION
The publish-local copied directly the files into the maven repository, causing issues when working on SNAPSHOT versions. For example, maven always downloaded from the remote repository because it didn't find the local version to be newer.
We now use a maven command which update every information that has to be.